### PR TITLE
set c standard to c99/gnu99 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,15 @@
 cmake_minimum_required (VERSION 2.8.4)
 project (gbsim)
 
+# set c version to gnu99
+if (CMAKE_VERSION VERSION_LESS "3.1")
+	if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+	  set (CMAKE_C_FLAGS "--std=gnu99 ${CMAKE_C_FLAGS}")
+	endif ()
+else ()
+	set (CMAKE_C_STANDARD 99)
+endif ()
+
 # Don't include simavr - the sim_core_decl.h in there was auto-generated,
 # so use the manually created one in include instead
 include_directories(


### PR DESCRIPTION
Build currently fails on systems where gcc defaults to c standard c90 or before. 
This should fix that problem.

Tested on my system
- `cmake version 2.8.12.2`
- `gcc (Ubuntu 4.8.5-2ubuntu1~14.04.1) 4.8.5`
- `Linux 3.13.0-86-generic x86_64`
